### PR TITLE
chore(karma-es6): add karma-es6-shim to karma frameworks

### DIFF
--- a/build/karma.conf.js
+++ b/build/karma.conf.js
@@ -17,7 +17,7 @@ const karmaConfig = {
     }
   ],
   singleRun: !argv.watch,
-  frameworks: ['mocha', 'chai-sinon', 'chai-as-promised', 'chai'],
+  frameworks: ['mocha', 'chai-sinon', 'chai-as-promised', 'chai', 'es6-shim'],
   preprocessors: {
     [`${config.dir_test}/**/*.js`]: ['webpack']
   },

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "karma-chai-as-promised": "^0.1.2",
     "karma-chai-sinon": "^0.1.5",
     "karma-coverage": "^0.5.0",
+    "karma-es6-shim": "^0.2.0",
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^0.2.1",
     "karma-spec-reporter": "0.0.23",


### PR DESCRIPTION
Integrating react-flexbox-grid resulted in strange errors in tests like
`Object.assign` missing.

Adding es6-shim to karma frameworks fixed this.
